### PR TITLE
Compatability with dgraph 1.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ transactions and connection pooling.
 Small, efficient codebase. Aims for a full Dgraph support. Supports transactions (starting from Dgraph version: `1.0.9`),
 delete mutations and low-level parameterized queries. DSL is planned.
 
+Now supports the new dgraph 1.1.x [Type System](https://docs.dgraph.io/master/query-language/#type-system). 
+
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed

--- a/lib/api.proto
+++ b/lib/api.proto
@@ -37,33 +37,28 @@ option java_outer_classname = "DgraphProto";
 service Dgraph {
 	rpc Login (LoginRequest)       returns (Response) {}
 	rpc Query (Request)            returns (Response) {}
-	rpc Mutate (Mutation)          returns (Assigned) {}
 	rpc Alter (Operation)          returns (Payload) {}
 	rpc CommitOrAbort (TxnContext) returns (TxnContext) {}
 	rpc CheckVersion(Check)        returns (Version) {}
 }
 
 message Request {
-	string query = 1;
-	map<string, string> vars = 2; // Support for GraphQL like variables.
+	uint64 start_ts = 1;
 
-	uint64 start_ts = 13;
-	LinRead lin_read = 14;
-	bool read_only = 15;
-	bool best_effort = 16;
+	string query = 4;
+	map<string, string> vars = 5; // Support for GraphQL like variables.
+	bool read_only = 6;
+	bool best_effort = 7;
+
+	repeated Mutation mutations = 12;
+	bool commit_now = 13;
 }
 
 message Response {
 	bytes json = 1;
-	repeated SchemaNode schema = 2 [deprecated=true];
-	TxnContext txn = 3;
-	Latency latency = 12;
-}
-
-message Assigned {
-	map<string, string> uids = 1;
-	TxnContext context = 2;
-	Latency latency = 12;
+	TxnContext txn = 2;
+	Latency latency = 3;
+	map<string, string> uids = 12;
 }
 
 message Mutation {
@@ -71,13 +66,14 @@ message Mutation {
 	bytes delete_json = 2;
 	bytes set_nquads = 3;
 	bytes del_nquads = 4;
-	string query = 5;
+	repeated NQuad set = 5;
+	repeated NQuad del = 6;
 
-	repeated NQuad set = 10;
-	repeated NQuad del = 11;
-	uint64 start_ts = 13;
+	// This is being used for upserts.
+	string cond = 9;
+
+	// This field is a duplicate of the one in Request and placed here for convenience.
 	bool commit_now = 14;
-	bool ignore_index_conflict = 15; // this field is not parsed and used by the server anymore.
 }
 
 message Operation {
@@ -110,7 +106,6 @@ message TxnContext {
 	bool aborted = 3;
 	repeated string keys = 4;  // List of keys to be used for conflict detection.
 	repeated string preds = 5; // List of predicates involved in this transaction.
-	LinRead lin_read = 13;
 }
 
 message Check {}
@@ -119,20 +114,11 @@ message Version {
 	string tag = 1;
 }
 
-message LinRead {
-	enum Sequencing {
-		CLIENT_SIDE = 0;
-		SERVER_SIDE = 1;
-	}
-
-	map<uint32, uint64> ids = 1;
-	Sequencing sequencing = 2;
-}
-
 message Latency {
 	uint64 parsing_ns = 1;
 	uint64 processing_ns = 2;
 	uint64 encoding_ns = 3;
+	uint64 assign_timestamp_ns = 4;
 }
 
 message NQuad {
@@ -175,18 +161,6 @@ message Facet {
 	ValType val_type = 3;
 	repeated string tokens = 4; // tokens of value.
 	string alias = 5; // not stored, only used for query.
-}
-
-message SchemaNode {
-	string predicate = 1;
-	string type = 2;
-	bool index = 3;
-	repeated string tokenizer = 4;
-	bool reverse = 5;
-	bool count = 6;
-	bool list = 7;
-	bool upsert = 8;
-	bool lang = 9;
 }
 
 message LoginRequest {

--- a/lib/dlex/adapters/grpc.ex
+++ b/lib/dlex/adapters/grpc.ex
@@ -78,7 +78,7 @@ defmodule Dlex.Adapters.GRPC do
 
   @impl true
   def mutate(channel, request, _json_lib, opts) do
-    ApiStub.mutate(channel, request, opts)
+    ApiStub.query(channel, request, opts)
   end
 
   @impl true

--- a/lib/dlex/type/operation.ex
+++ b/lib/dlex/type/operation.ex
@@ -40,8 +40,39 @@ defmodule Dlex.Type.Operation do
 
   def encode_schema(string) when is_binary(string), do: string
 
-  def encode_schema(schemas) when is_list(schemas) or is_map(schemas) do
+  def encode_schema(schemas) when is_map(schemas) do
+    encoded_preds = encode_schema(schemas["schema"])
+    encoded_types = encode_types(schemas["types"])
+
+    """
+      #{encoded_types}
+
+      #{encoded_preds}
+    """
+  end
+
+  def encode_schema(schemas) when is_list(schemas) do
     schemas |> List.wrap() |> Enum.map_join("\n", &transform_schema/1)
+  end
+
+  def encode_types([]), do: ""
+
+  def encode_types(types) do 
+    types |>
+      List.wrap() |>
+      Enum.map_join("\n", &transform_type/1)
+  end
+
+  defp transform_type(%{"name" => name, "fields" => fields}) do
+    fields_str = Enum.map_join(fields, "\n", fn(field) -> 
+      "#{field["name"]}: #{field["type"]}"
+    end)
+
+    """
+      type #{name}{
+        #{fields_str}
+      }
+    """
   end
 
   defp transform_schema(%{"predicate" => predicate, "type" => type} = entry) do

--- a/lib/dlex/type/query.ex
+++ b/lib/dlex/type/query.ex
@@ -20,10 +20,6 @@ defmodule Dlex.Type.Query do
   end
 
   @impl true
-  def decode(_, %Response{json: "{}", schema: schema}, _) do
-    Enum.map(schema, &Map.delete(&1, :__struct__))
-  end
-
   def decode(%{json: json_lib}, %Response{json: json, txn: %TxnContext{aborted: false} = _txn}, _) do
     with json when is_binary(json) <- json, do: json_lib.decode!(json)
   end

--- a/test/dlex/node_test.exs
+++ b/test/dlex/node_test.exs
@@ -17,16 +17,28 @@ defmodule Dlex.NodeTest do
     end
 
     test "alter" do
-      assert [
-               %{
-                 "index" => true,
-                 "predicate" => "user.name",
-                 "tokenizer" => ["term"],
-                 "type" => "string"
-               },
-               %{"predicate" => "user.age", "type" => "int"},
-               %{"predicate" => "user.friends", "type" => "uid"}
-             ] == User.__schema__(:alter)
+      assert %{ 
+              "schema" => [
+                 %{
+                   "index" => true,
+                   "predicate" => "user.name",
+                   "tokenizer" => ["term"],
+                   "type" => "string"
+                 },
+                 %{"predicate" => "user.age", "type" => "int"},
+                 %{"predicate" => "user.friends", "type" => "uid"}
+              ],
+              "types" => [
+                %{
+                  "fields" => [
+                    %{"name" => "user.friends", "type" => "uid"},
+                    %{"name" => "user.age", "type" => "integer"},
+                    %{"name" => "user.name", "type" => "string"}
+                  ],
+                  "name" => "type.user"
+                }
+              ]
+            } == User.__schema__(:alter)
     end
 
     test "transformation callbacks" do


### PR DESCRIPTION
This PR completely updates Dlex to be compatible with new Dgraph 1.1.x conventions; above all the new [Type System](https://docs.dgraph.io/master/query-language/#type-system). 

Most of the changes are straight-forward: 

1. For `expand(_all_)` to work you must create a type and assign a `dgraph.type` predicate in the mutations. 
2. For all the node/repo (ecto) stuff I've preserved the idea of namespacing predicates, but I've replaced the `type.*` predicates with actual `dgraph.type` references. 
3. Also I've made it so that `Repo.alter_schema()` correctly creates necessary dgraph types that correspond to each Node. 
4. Finally, all of the Dlex tests were updated and still pass. 

The _only_ thing that I was un-able to recreate in the newest version of dgraph was JSON upserts. In fact, I think this has been changed in such a way in dgraph that upserts only work with Nquads, though I could be wrong. There are 0 examples of JSON upserts in the dgraph documentation, or even in the [dgo](https://github.com/dgraph-io/dgo) (dgraph Go client) package documentation.