### PR TITLE
Alter schema when it's empty

### DIFF
--- a/lib/dlex/repo.ex
+++ b/lib/dlex/repo.ex
@@ -234,6 +234,10 @@ defmodule Dlex.Repo do
     end
   end
 
+  defp do_alter_schema(conn, sch, snapshot) do
+    do_alter_schema(conn, Map.put_new(sch, "types", []), snapshot)
+  end
+
   @doc """
   Generate snapshot for running meta process
   """


### PR DESCRIPTION
Using the setup from `test/test_helper.ex`, I get an error when running `TestRepo.alter_schema` when the schema is already empty:

```elixir
# drop the schema manhunally from ratel UI
{:ok, pid} = TestRepo.start_link()
TestRepo.register(User)
TestRepo.alter_schema
```

This PR fixes the issue.