### PR TITLE
Add server start and stop scripts and updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ Dlex.alter(conn, [
 
 ## Developers guide
 
+### Running tests
+
+1. Install dependencies `mix deps.get`
+2. Start the local dgraph server (requires Docker) `./start-server.sh`
+   This starts a local server bound to ports 9090 (GRPC) and 8090 (HTTP)
+3. Run `mix test`
+
+NOTE: You may stop the server using `./stop-server.sh`
+
 ### By updating api.proto
 
 #### Install development dependencies

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+DGRAPH_CONTAINER_NAME=dlex-dgraph
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^${DGRAPH_CONTAINER_NAME}\$"; then
+  echo "Already running..."
+else
+  echo "Starting local dgraph server via Docker..."
+  docker run --name $DGRAPH_CONTAINER_NAME -p 8090:8080 -p 9080:9090 -d dgraph/standalone:v1.1.0
+fi
+echo "Done."

--- a/stop-server.sh
+++ b/stop-server.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+DGRAPH_CONTAINER_NAME=dlex-dgraph
+
+if docker ps -a --format '{{.Names}}' | grep -Eq "^${DGRAPH_CONTAINER_NAME}\$"; then
+  echo "Stopping and removing dgraph server..."
+  docker stop $DGRAPH_CONTAINER_NAME && docker rm $DGRAPH_CONTAINER_NAME
+else
+  echo "Not running!"
+fi
+echo "Done."

--- a/test/dlex/repo_test.exs
+++ b/test/dlex/repo_test.exs
@@ -4,7 +4,7 @@ defmodule Dlex.RepoTest do
   alias Dlex.{TestRepo, User}
 
   setup_all do
-    {:ok, pid} = TestRepo.start_link()
+    {:ok, pid} = TestRepo.start_link(port: 9090)
     %{pid: pid}
   end
 

--- a/test/dlex_test.exs
+++ b/test/dlex_test.exs
@@ -2,9 +2,9 @@ defmodule DlexTest do
   use ExUnit.Case
 
   setup_all do
-    # {:ok, pid} = Dlex.start_link(pool_size: 2, port: 8080, transport: :http)
-    {:ok, pid} = Dlex.start_link(pool_size: 2)
 
+    # Setup our server
+    {:ok, pid} = Dlex.start_link(pool_size: 2, port: 9090)
     Dlex.alter!(pid, %{drop_all: true})
 
     schema = """


### PR DESCRIPTION
Simple start and stop scripts for Docker standalone Dgraph server to help make tests easier. Changed the port to `9090` instead of `9080` for GPRC and `8080` to `8090` for HTTP because some people may already have development instances of Dgraph running but don't want the tests to clear their entire database.