### PR TITLE
Return `queries` when doing upsert for mutation

### DIFF
--- a/lib/dlex.ex
+++ b/lib/dlex.ex
@@ -148,21 +148,20 @@ defmodule Dlex do
             _:bar <name> "Bar" .
            "
       iex> Dlex.mutate(conn, mutation)
-      {:ok, %{"bar" => "0xfe04c", "foo" => "0xfe04b"}}
+      {:ok, %{uids: %{"bar" => "0xfe04c", "foo" => "0xfe04b"}, queries: %{}}}
 
   Using `json`
 
-      iex> json = %{"name" => "Foo",
-                    "owns" => [%{"name" => "Bar"}]}
+      iex> json = %{"name" => "Foo", "owns" => [%{"name" => "Bar"}]}
            Dlex.mutate(conn, json)
-      {:ok, %{"blank-0" => "0xfe04d", "blank-1" => "0xfe04e"}}
+      {:ok, %{uids: %{"blank-0" => "0xfe04d", "blank-1" => "0xfe04e"}, queries: %{}}}
       iex> Dlex.mutate(conn, json, return_json: true)
       {:ok,
-       %{
+       %{ json: %{
          "name" => "Foo",
          "owns" => [%{"name" => "Bar", "uid" => "0xfe050"}],
          "uid" => "0xfe04f"
-       }}
+       }}}
 
   ## Options
 
@@ -236,28 +235,17 @@ defmodule Dlex do
 
   Example of usage
 
-      iex> mutation = "
-           _:foo <name> "Foo" .
-           _:foo <owns> _:bar .
-            _:bar <name> "Bar" .
-           "
-      iex> Dlex.delete(conn, mutation)
-      {:ok, %{"bar" => "0xfe04c", "foo" => "0xfe04b"}}
+      iex> Dlex.delete(conn, %{"uid" => "0xfe04c"})
+      {:ok, %{queries: %{}, uids: %{}}}
 
   Using `json`
 
-      iex> json = %{"name" => "Foo",
-                    "owns" => [%{"name" => "Bar"}]}
+      iex> json = %{"uid" => "0xfe04c"}
            Dlex.delete(conn, json)
-      {:ok, %{"blank-0" => "0xfe04d", "blank-1" => "0xfe04e"}}
+      {:ok, %{queries: %{}, uids: %{}}}
 
       iex> Dlex.delete(conn, json, return_json: true)
-      {:ok,
-       %{
-         "name" => "Foo",
-         "owns" => [%{"name" => "Bar", "uid" => "0xfe050"}],
-         "uid" => "0xfe04f"
-       }}
+      {:ok, %{json: %{"uid" => "0xfe04c"}, queries: %{}, uids: %{}}}
 
   ## Options
 

--- a/lib/dlex/repo.ex
+++ b/lib/dlex/repo.ex
@@ -120,7 +120,7 @@ defmodule Dlex.Repo do
   def mutate(conn, data, opts) do
     data_with_ids = Utils.add_blank_ids(data, :uid)
 
-    with {:ok, ids_map} <- Dlex.mutate(conn, %{}, encode(data_with_ids), opts) do
+    with {:ok, %{uids: ids_map}} <- Dlex.mutate(conn, %{}, encode(data_with_ids), opts) do
       {:ok, Utils.replace_ids(data_with_ids, ids_map, :uid)}
     end
   end

--- a/lib/dlex/type/mutation.ex
+++ b/lib/dlex/type/mutation.ex
@@ -68,7 +68,14 @@ defmodule Dlex.Type.Mutation do
   defp mutation_key(:nquads, :deletion), do: :del_nquads
 
   @impl true
-  def decode(%Query{statement: statement} = _query, %Response{uids: uids} = _result, opts) do
-    if opts[:return_json], do: Utils.replace_ids(statement, uids), else: uids
+  def decode(%Query{statement: statement, json: json_lib, type: Dlex.Type.Mutation} = _query, %Response{uids: uids, json: json} = _result, opts) do
+    queries = if json == "", do: %{}, else: json_lib.decode!(json)
+    result = %{uids: uids, queries: queries}
+    if opts[:return_json] do
+      j = if is_binary(statement), do: %{}, else: Utils.replace_ids(statement, uids)
+      Map.put(result, :json, j)
+    else
+      result
+    end
   end
 end

--- a/test/dlex_test.exs
+++ b/test/dlex_test.exs
@@ -109,7 +109,7 @@ defmodule DlexTest do
              )
 
     assert %{"uid" => ^uid} = get_by_name(pid, "deletion_test")
-    assert Dlex.delete!(pid, %{"uid" => uid})
+    assert Dlex.delete!(pid, %{"uid" => uid}, return_json: true) |> IO.inspect(label: "Delete")
     assert %{"all" => []} = get_by_name(pid, "deletion_test")
   end
 


### PR DESCRIPTION
Return the queries made during upsert so that we can find the existing `uid` of a node in the case where the node already exists.
**THIS IS A BREAKING CHANGE** @liveforeverx approved of.

`Dlex.mutate` now returns `%{ uids: %{}, queries: %{}}` by default. `return_json: true` returns `%{ uids: %{}, queries: %{}, json: %{}}`