### PR TITLE
Add "queries" to :json key in %Response{} for :http adapter

### DIFF
--- a/lib/dlex/adapters/http.ex
+++ b/lib/dlex/adapters/http.ex
@@ -179,8 +179,8 @@ if Code.ensure_loaded?(Mint.HTTP) do
       Dlex.Api.Payload.new(Data: data)
     end
 
-    defp parse_success(:mutate, %{"data" => %{"uids" => uids}} = response) do
-      Dlex.Api.Response.new(txn: parse_txn(response), uids: uids)
+    defp parse_success(:mutate, %{"data" => %{"uids" => uids, "queries" => queries}} = response) do
+      Dlex.Api.Response.new(txn: parse_txn(response), uids: uids, json: queries)
     end
 
     defp parse_success(:query, %{"data" => data} = response) do

--- a/lib/dlex/type/mutation.ex
+++ b/lib/dlex/type/mutation.ex
@@ -67,10 +67,14 @@ defmodule Dlex.Type.Mutation do
   defp mutation_key(:json, :deletion), do: :delete_json
   defp mutation_key(:nquads, :deletion), do: :del_nquads
 
+  defp parse_json(_json_lib, ""), do: %{}
+  defp parse_json(_json_lib, nil), do: %{}
+  defp parse_json(_json_lib, j) when is_map(j), do: j
+  defp parse_json(json_lib, j) when is_binary(j), do: json_lib.decode!(j)
+
   @impl true
   def decode(%Query{statement: statement, json: json_lib, type: Dlex.Type.Mutation} = _query, %Response{uids: uids, json: json} = _result, opts) do
-    queries = if json == "", do: %{}, else: json_lib.decode!(json)
-    result = %{uids: uids, queries: queries}
+    result = %{uids: uids, queries: parse_json(json_lib, json)}
     if opts[:return_json] do
       j = if is_binary(statement), do: %{}, else: Utils.replace_ids(statement, uids)
       Map.put(result, :json, j)

--- a/test/dlex_test.exs
+++ b/test/dlex_test.exs
@@ -109,7 +109,7 @@ defmodule DlexTest do
              )
 
     assert %{"uid" => ^uid} = get_by_name(pid, "deletion_test")
-    assert Dlex.delete!(pid, %{"uid" => uid}, return_json: true) |> IO.inspect(label: "Delete")
+    assert Dlex.delete!(pid, %{"uid" => uid}, return_json: true)
     assert %{"all" => []} = get_by_name(pid, "deletion_test")
   end
 


### PR DESCRIPTION
Fixes failing test for `:http` adapter and removes an IO.inspect that snuck in