### PR TITLE
Add Ecto.Changeset pattern match, fix data sent to mutate().

### DIFF
--- a/lib/dlex/repo.ex
+++ b/lib/dlex/repo.ex
@@ -112,9 +112,10 @@ defmodule Dlex.Repo do
   @doc """
   Mutate data
   """
-  def mutate(conn, %{__struct__: Ecto.Changeset, changes: changes, data: %type{uid: uid}}, opts) do
-    data = struct(type, Map.put(changes, :uid, uid))
-    mutate(conn, data, opts)
+  def mutate(conn, %{__struct__: Ecto.Changeset, valid?: false} = struct, opts), do: {:error, struct}
+
+  def mutate(conn, %{__struct__: Ecto.Changeset, valid?: true, changes: changes}, opts) do
+    mutate(conn, changes, opts)
   end
 
   def mutate(conn, data, opts) do

--- a/lib/dlex/repo.ex
+++ b/lib/dlex/repo.ex
@@ -112,7 +112,7 @@ defmodule Dlex.Repo do
   @doc """
   Mutate data
   """
-  def mutate(conn, %{__struct__: Ecto.Changeset, valid?: false} = struct, opts), do: {:error, struct}
+  def mutate(_conn, %{__struct__: Ecto.Changeset, valid?: false} = struct, _opts), do: {:error, struct}
 
   def mutate(conn, %{__struct__: Ecto.Changeset, valid?: true, changes: changes}, opts) do
     mutate(conn, changes, opts)

--- a/test/dlex/repo_test.exs
+++ b/test/dlex/repo_test.exs
@@ -27,6 +27,12 @@ defmodule Dlex.RepoTest do
 
       assert {:ok, %{"uid_get" => [%{"uid" => _, "user.age" => 25, "user.name" => "Alice"}]}} =
                TestRepo.all("{uid_get(func: uid(#{uid})) {uid expand(_all_)}}")
+
+      invalid_changeset = Ecto.Changeset.cast(%User{}, %{name: 20, age: "Bernard"}, [:name, :age])
+      assert {:error, %Ecto.Changeset{valid?: false}} = TestRepo.set(invalid_changeset)
+
+      valid_changeset = Ecto.Changeset.cast(%User{}, %{name: "Bernard", age: 20}, [:name, :age])
+      assert {:ok, %User{uid: uid}} = TestRepo.set(valid_changeset)
     end
   end
 end

--- a/test/dlex/repo_test.exs
+++ b/test/dlex/repo_test.exs
@@ -32,7 +32,7 @@ defmodule Dlex.RepoTest do
       assert {:error, %Ecto.Changeset{valid?: false}} = TestRepo.set(invalid_changeset)
 
       valid_changeset = Ecto.Changeset.cast(%User{}, %{name: "Bernard", age: 20}, [:name, :age])
-      assert {:ok, %User{uid: uid}} = TestRepo.set(valid_changeset)
+      assert {:ok, %{uid: uid}} = TestRepo.set(valid_changeset)
     end
   end
 end


### PR DESCRIPTION
The `Ecto.Changeset, valid?: false` pattern match allows people to use Ecto Changeset in Dlex like they would with Ecto. If the changeset is valid, data is mutated in Dgraph, else returns `{:error, changeset}`. 

For example: `changeset = Post.create_changeset(Post{}, params)` with `Repo.set(changeset)`

Furthermore, inserting data via changesets resulted in error: `no function clause matching in MyApp.Post.__schema__/2`. It also added unwanted fields from Ecto Changeset like `__meta__`, `id`, and predicates from schema with `nil` values. This was because `data = struct(type, Map.put(changes, :uid, uid))` created a struct over which encode_kv() couldn't pattern match.

Now, data is inserted as expected using the Ecto.Changeset `changes` field.