### PR TITLE
Handle DateTime fields through Repo

### DIFF
--- a/lib/dlex/node.ex
+++ b/lib/dlex/node.ex
@@ -238,7 +238,7 @@ defmodule Dlex.Node do
     float: "float",
     string: "string",
     geo: "geo",
-    datetime: "datetime",
+    utc_datetime: "datetime",
     uid: "[uid]"
   ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule Dlex.MixProject do
     [
       {:db_connection, "~> 2.1"},
       {:grpc, "~> 0.3.1"},
+      {:calendar, "~> 1.0.0"},
       {:jason, "~> 1.0", optional: true},
       {:mint, "~> 1.0", optional: true},
       {:castore, "~> 0.1.4", optional: true},

--- a/test/dlex/node_test.exs
+++ b/test/dlex/node_test.exs
@@ -8,7 +8,7 @@ defmodule Dlex.NodeTest do
       assert "user" == User.__schema__(:source)
       assert :string == User.__schema__(:type, :name)
       assert :integer == User.__schema__(:type, :age)
-      assert [:name, :age, :friends, :location] == User.__schema__(:fields)
+      assert [:name, :age, :friends, :location, :modified] == User.__schema__(:fields)
     end
 
     test "alter" do
@@ -22,11 +22,13 @@ defmodule Dlex.NodeTest do
                  },
                  %{"predicate" => "user.age", "type" => "int"},
                  %{"predicate" => "user.friends", "type" => "[uid]"},
-                 %{"predicate" => "user.location", "type" => "geo"}
+                 %{"predicate" => "user.location", "type" => "geo"},
+                 %{"predicate" => "user.modified", "type" => "datetime"}
                ],
                "types" => [
                  %{
                    "fields" => [
+                     %{"name" => "user.modified", "type" => "datetime"},
                      %{"name" => "user.location", "type" => "geo"},
                      %{"name" => "user.friends", "type" => "[uid]"},
                      %{"name" => "user.age", "type" => "int"},

--- a/test/dlex/repo_test.exs
+++ b/test/dlex/repo_test.exs
@@ -36,6 +36,14 @@ defmodule Dlex.RepoTest do
       assert {:ok, %{uid: _uid}} = TestRepo.set(valid_changeset)
     end
 
+    test "setting datetime field in Changeset" do
+      now = DateTime.utc_now()
+      changeset = Ecto.Changeset.cast(%User{}, %{name: "TimeTraveler", age: 20, modified: now}, [:name, :age, :modified])
+      assert {:ok, %{uid: uid}} = TestRepo.set(changeset)
+
+      assert {:ok, %User{name: "TimeTraveler", age: 20, modified: now}} = TestRepo.get(uid)
+    end
+
     test "using custom types" do
       changes = %{name: "John", age: 30, location: %{lat: 15.5, lon: 10.2}}
       changeset = Changeset.cast(%User{}, changes, [:name, :age, :location])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -48,6 +48,7 @@ defmodule Dlex.User do
     field :age, :integer
     field :friends, :uid
     field :location, Dlex.Geo
+    field :modified, :utc_datetime
     field :cache, :any, virtual: true
   end
 end


### PR DESCRIPTION
I don't know if I did this the right way, but as is the Repo.set and Repo.get functions were not handling :datetime attributes

The first change was to use an Ecto.Type that exists.  :utc_datetime is the Ecto type that matches.

Dgraph encodes datetime attributes as rfc3339.  I did not find a native rfc3339 parsing/formatting library so I brought int Calendar 1.0

Finally, I modified decoding and encoding fields to turn DateTime structs into rfc3339 strings and :utc_datetime rfc3339 strings into DateTime structs

I need these changes to continue to move forward using this library in my project.