### PR TITLE
Add Repo.delete().

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Preferred and more performant option is to use `grpc`:
 def deps do
   [
     {:jason, "~> 1.0"},
-    {:dlex, "~> 0.1.0"}
+    {:dlex, "~> 0.5.0"}
   ]
 end
 ```
@@ -34,7 +34,7 @@ def deps do
     {:jason, "~> 1.0"},
     {:castore, "~> 0.1.0", optional: true},
     {:mint, github: "ericmj/mint", branch: "master"},
-    {:dlex, "~> 0.1.0"}
+    {:dlex, "~> 0.5.0"}
   ]
 end
 ```

--- a/lib/dlex/repo.ex
+++ b/lib/dlex/repo.ex
@@ -49,6 +49,9 @@ defmodule Dlex.Repo do
       def mutate(node, opts \\ []), do: Dlex.Repo.mutate(@name, node, opts)
       def mutate!(node, opts \\ []), do: Dlex.Repo.mutate!(@name, node, opts)
 
+      def delete(node, opts \\ []), do: Dlex.Repo.delete(@name, node, opts)
+      def delete!(node, opts \\ []), do: Dlex.Repo.delete!(@name, node, opts)
+
       def get(uid), do: Dlex.Repo.get(@name, meta(), uid)
       def get!(uid), do: Dlex.Repo.get!(@name, meta(), uid)
 
@@ -110,7 +113,7 @@ defmodule Dlex.Repo do
   end
 
   @doc """
-  Mutate data
+  Mutate data.
   """
   def mutate(_conn, %{__struct__: Ecto.Changeset, valid?: false} = changeset, _opts),
     do: {:error, changeset}
@@ -135,6 +138,29 @@ defmodule Dlex.Repo do
         with {:ok, %{uids: ids_map}} <- Dlex.set(conn, %{}, encoded_data, opts) do
           {:ok, Utils.replace_ids(data_with_ids, ids_map, :uid)}
         end
+    end
+  end
+
+  @doc """
+  Delete data.
+  """
+  def delete(conn, data, _opts) do
+    case encode(data) do
+      {:error, error} ->
+        {:error, %Error{action: :mutate, reason: error}}
+
+      encoded_data ->
+        Dlex.delete(conn, encoded_data)
+    end
+  end
+
+  @doc """
+  The same as `delete/2`, but return result of sucessful operation or raises.
+  """
+  def delete!(conn, data, opts) do
+    case delete(conn, data, opts) do
+      {:ok, result} -> result
+      {:error, error} -> raise error
     end
   end
 

--- a/test/dlex/repo_test.exs
+++ b/test/dlex/repo_test.exs
@@ -33,7 +33,11 @@ defmodule Dlex.RepoTest do
       assert {:error, %Ecto.Changeset{valid?: false}} = TestRepo.set(invalid_changeset)
 
       valid_changeset = Ecto.Changeset.cast(%User{}, %{name: "Bernard", age: 20}, [:name, :age])
-      assert {:ok, %{uid: _uid}} = TestRepo.set(valid_changeset)
+      assert {:ok, %{uid: uid2}} = TestRepo.set(valid_changeset)
+
+      assert uid2 != nil
+      assert {:ok, %{queries: %{}, uids: %{}}} = TestRepo.delete(%{uid: uid2})
+      assert {:ok, nil} = TestRepo.get(uid2)
     end
 
     test "using custom types" do


### PR DESCRIPTION
I added Repo.delete() and .delete!() to repo.ex. This allows deleting nodes and array-based predicates in the same way as you would create nodes with Repo.set() and Repo.mutate().

I included a test that deletes a node by :uid, and then confirms that it is deleted.